### PR TITLE
Dev/simplify dataset download

### DIFF
--- a/config/data_paths/default.yaml
+++ b/config/data_paths/default.yaml
@@ -1,2 +1,2 @@
-habitat_scene_dir: '/data/mp3d_data/tasks/mp3d'
-vlmaps_data_dir: '/data/mp3d_data/vlmaps_dataset'
+habitat_scene_dir: 'data/mp3d'
+vlmaps_data_dir: 'data/vlmaps_dataset'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,8 @@ services:
     
     # Volume mounts
     volumes:
-      # Mount project files (current directory) to /vlmaps in container
+      # Mount project files (current directory) to /vlmaps in container (includes ./data)
       - .:/vlmaps
-      # Mount Matterport3D data directory (must be set via VLMAPS_MP3D_DATA_DIR env var)
-      - ${VLMAPS_MP3D_DATA_DIR}:/data/mp3d_data
       # Preserve bash history
       - vlmaps-bash-history:/root/.bash_history
       # X11 forwarding

--- a/docs/01-setup.md
+++ b/docs/01-setup.md
@@ -15,40 +15,9 @@ git clone https://github.com/vlmaps/vlmaps.git
 cd vlmaps
 ```
 
-## Step 2: Set Up Matterport3D Data Directory
+## Step 2: Prepare the Data Directory
 
-Set the environment variable for where you want to store the Matterport3D dataset (~50GB). This directory will be mounted as a volume in the container.
-
-### For Bash/Zsh:
-```bash
-export VLMAPS_MP3D_DATA_DIR=/path/to/your/data
-```
-
-### For Fish Shell:
-```fish
-set -x VLMAPS_MP3D_DATA_DIR /path/to/your/data
-```
-
-### For Permanent Setup (Bash/Zsh):
-Add to your `~/.bashrc` or `~/.zshrc`:
-```bash
-export VLMAPS_MP3D_DATA_DIR=/path/to/your/data
-```
-
-### For Permanent Setup (Fish):
-Add to `~/.config/fish/config.fish`:
-```fish
-set -x VLMAPS_MP3D_DATA_DIR /path/to/your/data
-```
-
-### Using Docker Compose Projects (Recommended)
-
-Alternatively, create a `.env` file in the project root:
-```bash
-echo "VLMAPS_MP3D_DATA_DIR=/path/to/your/data" > .env
-```
-
-Docker Compose will automatically read this file.
+Dataset files now live inside the repository under `data/`. The download script will create and populate this folder for you, so no environment variables or extra mounts are required. Ensure you have ~50GB free in the repo location.
 
 ## Step 3: Build and Start the Container
 

--- a/docs/02-download-mp3d.md
+++ b/docs/02-download-mp3d.md
@@ -22,25 +22,13 @@ This guide will help you download the Matterport3D dataset required for VLMaps.
 cp /path/to/downloaded/script.py download_mp.py
 ```
 
-## Step 2: Verify VLMAPS_MP3D_DATA_DIR is Set
-
-Ensure the environment variable is set (from Setup step):
-
-```bash
-# Check if it's set
-echo $VLMAPS_MP3D_DATA_DIR
-
-# If not set, set it (see Setup guide)
-export VLMAPS_MP3D_DATA_DIR=/path/to/your/data
-```
-
-## Step 3: Start the Container
+## Step 2: Start the Container
 
 ```bash
 ./scripts/start.bash
 ```
 
-## Step 4: Run the Download Script
+## Step 3: Run the Download Script
 
 Inside the container, run the download script:
 
@@ -57,39 +45,24 @@ Or with a specific scene ID:
 ### What the Script Does
 
 1. **Checks for download_mp.py** - Verifies the script exists
-2. **Checks data directory** - Warns if data already exists
-3. **Downloads scans** - Downloads scene data for the specified scene ID
-4. **Downloads tasks** - Downloads habitat task data
-5. **Organizes data** - Structures data into `scans/` and `tasks/` directories
-6. **Updates config** - Prompts to update `config/data_paths/default.yaml`
+2. **Creates data directory** - Ensures `data/` is available
+3. **Downloads habitat bundle** - Fetches `mp3d_habitat.zip` (~15GB) into `data/`
+4. **Extracts data** - Unzips into `data/mp3d/` with `scans/` and `tasks/`
 
-### Script Options
+## Step 4: Update Configuration
 
-When data already exists, you'll be prompted:
-- **yes** - Overwrite existing data
-- **skip** - Skip download and only update config
-- **no** - Abort (still prompts for config update)
-
-## Step 5: Update Configuration
-
-The script will ask if you want to update the config file. If you choose **yes**, it will automatically update:
-
-- `config/data_paths/default.yaml`
-
-The config will be updated to:
+If you need to point configs to the downloaded data (from the project root), set paths like:
 ```yaml
-habitat_scene_dir: "/data/mp3d_data/scans"
-vlmaps_data_dir: "/data/mp3d_data/tasks/mp3d"
+habitat_scene_dir: "data/mp3d/scans"
+vlmaps_data_dir: "data/mp3d/tasks/mp3d"
 ```
-
-A backup of the original config will be saved as `config/data_paths/default.yaml.bak`.
 
 ## Data Structure
 
-After download, your data directory will have this structure:
+After download, your data directory (under the project root) will have this structure:
 
 ```
-/data/mp3d_data/
+./data/mp3d/
 ├── scans/
 │   └── 17DRP5sb8fy/          # Scene directory
 │       ├── 17DRP5sb8fy.glb
@@ -110,10 +83,6 @@ After download, your data directory will have this structure:
 - Ensure the script is in the project root (visible at `/vlmaps/download_mp.py` in container)
 - Check file permissions: `chmod +x download_mp.py` (if needed)
 
-### VLMAPS_MP3D_DATA_DIR not set
-- Set it before starting the container: `export VLMAPS_MP3D_DATA_DIR=/path/to/data`
-- Or create a `.env` file in the project root
-
 ### Download fails
 - Check internet connection
 - Verify Matterport3D credentials are correct in `download_mp.py`
@@ -132,10 +101,10 @@ If you need to manually update the config:
 nano /vlmaps/config/data_paths/default.yaml
 ```
 
-Set:
+Set (relative to the project root):
 ```yaml
-habitat_scene_dir: "/data/mp3d_data/scans"
-vlmaps_data_dir: "/data/mp3d_data/tasks/mp3d"
+habitat_scene_dir: "data/mp3d/scans"
+vlmaps_data_dir: "data/mp3d/tasks/mp3d"
 ```
 
 ## Next Steps

--- a/docs/03-generate-dataset.md
+++ b/docs/03-generate-dataset.md
@@ -18,8 +18,8 @@ cat config/data_paths/default.yaml
 
 Should show:
 ```yaml
-habitat_scene_dir: "/data/mp3d_data/scans"
-vlmaps_data_dir: "/data/mp3d_data/tasks/mp3d"
+habitat_scene_dir: "data/mp3d/scans"
+vlmaps_data_dir: "data/mp3d/tasks/mp3d"
 ```
 
 ## Step 2: Configure Dataset Generation
@@ -64,7 +64,7 @@ nano config/generate_dataset.yaml
 Run the dataset generation script:
 
 ```bash
-cd dataset
+cd application/dataset
 python generate_dataset.py
 ```
 
@@ -79,10 +79,10 @@ python generate_dataset.py
 
 ### Expected Output Structure
 
-After generation, your data directory will look like:
+After generation, your data directory (under the project root) will look like:
 
 ```
-/data/mp3d_data/tasks/mp3d/
+./data/mp3d/tasks/mp3d/
 ├── 5LpN3gDmAk7_1/
 │   ├── rgb/
 │   │   ├── 000000.png
@@ -150,7 +150,7 @@ data_cfg:
 If you want to collect your own data in Habitat-Sim:
 
 ```bash
-python dataset/collect_custom_dataset.py scene_names=["gTV8FGcVJC9"]
+python application/dataset/collect_custom_dataset.py scene_names=["gTV8FGcVJC9"]
 ```
 
 This will create a new folder `<scene_name>_<id>` under `vlmaps_data_dir`. The `<id>` is automatically incremented if folders already exist.
@@ -182,14 +182,14 @@ This will create a new folder `<scene_name>_<id>` under `vlmaps_data_dir`. The `
 After generation, verify the data:
 
 ```bash
-# Check a scene directory
-ls -la /data/mp3d_data/tasks/mp3d/5LpN3gDmAk7_1/
+# Check a scene directory (run from project root)
+ls -la ./data/mp3d/tasks/mp3d/5LpN3gDmAk7_1/
 
 # Should see:
 # rgb/, depth/, semantic/, poses.txt
 
 # Check number of frames
-ls /data/mp3d_data/tasks/mp3d/5LpN3gDmAk7_1/rgb/ | wc -l
+ls ./data/mp3d/tasks/mp3d/5LpN3gDmAk7_1/rgb/ | wc -l
 ```
 
 ## Next Steps

--- a/docs/04-index-vlmap.md
+++ b/docs/04-index-vlmap.md
@@ -87,9 +87,9 @@ This will:
 
 ### Expected Output
 
-The map will be saved in the scene directory:
+The map will be saved in the scene directory (under project root):
 ```
-/data/mp3d_data/tasks/mp3d/5LpN3gDmAk7_1/
+./data/mp3d/tasks/mp3d/5LpN3gDmAk7_1/
 ├── rgb/
 ├── depth/
 ├── semantic/
@@ -243,8 +243,8 @@ depth_sample_rate: 4  # Sample 1/4 of pixels (faster, sparser)
 Check that the map was created:
 
 ```bash
-# List scene directory
-ls -lh /data/mp3d_data/tasks/mp3d/5LpN3gDmAk7_1/
+# List scene directory (run from project root)
+ls -lh ./data/mp3d/tasks/mp3d/5LpN3gDmAk7_1/
 
 # Should see map.npz file
 ```

--- a/scripts/download-mp3d.bash
+++ b/scripts/download-mp3d.bash
@@ -1,144 +1,58 @@
 #!/bin/bash
 
-# Script to download Matterport3D data using download_mp.py
-# This script is designed to run inside the dev container
-# Usage: ./scripts/download-mp3d.bash [SCENE_ID]
-# Example: ./scripts/download-mp3d.bash 17DRP5sb8fy
+set -euo pipefail
 
-set -e  # Exit on error
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ZIP_PATH="$PROJECT_ROOT/data/mp3d_habitat.zip"
+TARGET_DIR="$PROJECT_ROOT/data/mp3d"
+TEMP_V1_DIR="$PROJECT_ROOT/data/v1"
 
-# Data directory in container (mapped from VLMAPS_MP3D_DATA_DIR on host)
-DATA_DIR="/data/mp3d_data"
+log() {
+    printf '[download-mp3d] %s\n' "$1"
+}
 
-# Check if download_mp.py exists
-if [ ! -f "/vlmaps/download_mp.py" ]; then
-    echo "Error: download_mp.py not found in /vlmaps" >&2
-    echo "" >&2
-    echo "Please copy the download_mp.py script provided by Matterport3D into the project root." >&2
-    echo "It will be available at /vlmaps/download_mp.py in the container." >&2
+if [ ! -f "$PROJECT_ROOT/download_mp.py" ]; then
+    echo "Error: download_mp.py not found in $PROJECT_ROOT." >&2
+    echo "Place the Matterport-provided downloader in the project root." >&2
     exit 1
 fi
 
-# Function to update config file
-update_config_file() {
-    CONFIG_FILE="/vlmaps/config/data_paths/default.yaml"
-    if [ ! -f "$CONFIG_FILE" ]; then
-        echo "Warning: Config file not found at $CONFIG_FILE"
-        echo "You may need to create it or update the path manually."
+mkdir -p "$PROJECT_ROOT/data"
+
+download_zip() {
+    if [ -f "$ZIP_PATH" ]; then
+        log "Found existing mp3d_habitat.zip; skipping download."
         return
     fi
-    
-    echo ""
-    echo "Would you like to update config/data_paths/default.yaml to point to the data directory?"
-    echo ""
-    echo "Current config:"
-    cat "$CONFIG_FILE"
-    echo ""
-    read -p "Update config file? (yes/no): " update_config
-    
-    if [[ "$update_config" =~ ^[Yy][Ee][Ss]$ ]]; then
-        HABITAT_SCENE_DIR="$DATA_DIR/tasks/mp3d"
-        VLMAPS_DATA_DIR="$DATA_DIR/vlmaps_dataset"
-        
-        # Backup original config
-        cp "$CONFIG_FILE" "${CONFIG_FILE}.bak"
-        
-        # Update config file
-        sed -i "1s|.*|habitat_scene_dir: \"$HABITAT_SCENE_DIR\"|" "$CONFIG_FILE"
-        sed -i "2s|.*|vlmaps_data_dir: \"$VLMAPS_DATA_DIR\"|" "$CONFIG_FILE"
-        
-        echo ""
-        echo "Config file updated successfully!"
-        echo "Backup saved to: ${CONFIG_FILE}.bak"
-        echo ""
-        echo "New config:"
-        cat "$CONFIG_FILE"
-    else
-        echo "Config file not updated. You can update it manually later."
+
+    log "Downloading Habitat task bundle (mp3d_habitat.zip). This is ~15GB."
+    python download_mp.py -o "$PROJECT_ROOT/data" --task_data habitat
+
+    local legacy_zip="$TEMP_V1_DIR/tasks/mp3d_habitat.zip"
+    if [ -f "$legacy_zip" ]; then
+        mv "$legacy_zip" "$ZIP_PATH"
+        rm -rf "$TEMP_V1_DIR"
+    fi
+
+    if [ ! -f "$ZIP_PATH" ]; then
+        echo "Download finished but $ZIP_PATH not found." >&2
+        exit 1
     fi
 }
 
-# Check if data directory exists and has content
-OVERWRITE=false
-SHOULD_DOWNLOAD=true
-if [ -d "$DATA_DIR" ] && [ -n "$(ls -A "$DATA_DIR" 2>/dev/null)" ]; then
-    echo "Warning: Data directory already exists and contains files: $DATA_DIR" >&2
-    echo "" >&2
-    echo "Options:" >&2
-    echo "  1. Overwrite existing data (this will delete existing scans/ and tasks/ directories)" >&2
-    echo "  2. Skip download and only update config" >&2
-    echo "  3. Change VLMAPS_MP3D_DATA_DIR to a different directory and restart the container" >&2
-    echo "" >&2
-    read -p "Do you want to overwrite existing data? (yes/no/skip): " response
-    if [[ "$response" =~ ^[Ss][Kk][Ii][Pp]$ ]]; then
-        SHOULD_DOWNLOAD=false
-        echo "Skipping download. Will ask about config update..."
-    elif [[ ! "$response" =~ ^[Yy][Ee][Ss]$ ]]; then
-        echo "Aborted. Please set VLMAPS_MP3D_DATA_DIR to a different directory and restart the container." >&2
-        # Still ask about config before exiting
-        update_config_file
-        exit 1
-    else
-        OVERWRITE=true
-        echo "Proceeding with overwrite..."
-    fi
-fi
+extract_zip() {
+    rm -rf "$TARGET_DIR"
+    log "Extracting into $TARGET_DIR"
+    unzip -oq "$ZIP_PATH" -d "$PROJECT_ROOT/data"
 
-# Download data if needed
-if [ "$SHOULD_DOWNLOAD" = true ]; then
-    # Create data directory if it doesn't exist
-    mkdir -p "$DATA_DIR"
-    
-    # Clear existing scans and tasks directories if overwriting
-    if [ "$OVERWRITE" = true ]; then
-        echo "Clearing existing data directories..."
-        rm -rf "$DATA_DIR/scans" "$DATA_DIR/tasks"
-    fi
-    
-    # Get scene ID from argument or use default
-    SCENE_ID="${1:-17DRP5sb8fy}"
-    echo "Using scene ID: $SCENE_ID"
-    
-    echo "Downloading Matterport3D data to: $DATA_DIR"
-    echo "This may take a while (approximately 50GB)..."
-    echo ""
-    
-    # Download scans
-    echo "Downloading scans for scene $SCENE_ID..."
-    cd /vlmaps
-    python download_mp.py -o "$DATA_DIR/scans" --id "$SCENE_ID" || {
-        echo "Error: Failed to download scans" >&2
+    if [ ! -d "$TARGET_DIR" ]; then
+        echo "Extraction failed: expected $TARGET_DIR." >&2
         exit 1
-    }
-    if [ -d "$DATA_DIR/scans/v1/scans/$SCENE_ID" ]; then
-        cp -a "$DATA_DIR/scans/v1/scans/$SCENE_ID/." "$DATA_DIR/scans/" && \
-        rm -rf "$DATA_DIR/scans/v1"
     fi
-    
-    # Download tasks
-    echo "Downloading habitat tasks..."
-    python download_mp.py -o "$DATA_DIR/tasks" --task habitat
-    if [ -f "$DATA_DIR/tasks/v1/tasks/mp3d_habitat.zip" ]; then
-        unzip -q "$DATA_DIR/tasks/v1/tasks/mp3d_habitat.zip" -d "$DATA_DIR/tasks" && \
-        rm -rf "$DATA_DIR/tasks/v1"
-    fi
-    
-    # Create vlmaps_dataset directory for future use
-    mkdir -p "$DATA_DIR/vlmaps_dataset"
-    
-    echo ""
-    echo "Download complete!"
-    echo "Data is available at: $DATA_DIR"
-    echo ""
-    echo "Directory structure:"
-    echo "  $DATA_DIR/scans/         - Matterport3D scene scans"
-    echo "  $DATA_DIR/tasks/         - Habitat tasks"
-    echo "  $DATA_DIR/vlmaps_dataset - VLMaps dataset (will be populated by generate_dataset.py)"
-else
-    echo "Skipping download. Using existing data at: $DATA_DIR"
-    # Ensure vlmaps_dataset directory exists even when skipping download
-    mkdir -p "$DATA_DIR/vlmaps_dataset"
-fi
+}
 
-# Always ask to update config file (regardless of whether data was downloaded)
-update_config_file
+download_zip
+extract_zip
+
+log "Done. Scenes extracted under $TARGET_DIR and archive stored at $ZIP_PATH."

--- a/scripts/start.bash
+++ b/scripts/start.bash
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 # Script to start/attach to vlmaps dev container using docker-compose
-# Usage: ./scripts/start.bash [MP3D_DATA_DIR]
-# Example: ./scripts/start.bash /path/to/data
-# Or: VLMAPS_MP3D_DATA_DIR=/path/to/data ./scripts/start.bash
+# Usage: ./scripts/start.bash
 
 # Detect docker-compose command (supports both 'docker-compose' and 'docker compose')
 if command -v docker-compose &> /dev/null; then
@@ -12,27 +10,6 @@ elif docker compose version &> /dev/null; then
     DOCKER_COMPOSE="docker compose"
 else
     echo "Error: docker-compose not found. Please install docker-compose."
-    exit 1
-fi
-
-# Determine Matterport3D data directory
-# Priority: 1) Command line argument, 2) VLMAPS_MP3D_DATA_DIR env var, 3) Warn and exit
-if [ -n "$1" ]; then
-    # Command line argument takes precedence
-    export VLMAPS_MP3D_DATA_DIR="$1"
-    echo "Using Matterport3D data directory (from argument): $VLMAPS_MP3D_DATA_DIR"
-elif [ -n "$VLMAPS_MP3D_DATA_DIR" ]; then
-    # Use environment variable if set
-    echo "Using Matterport3D data directory (from VLMAPS_MP3D_DATA_DIR): $VLMAPS_MP3D_DATA_DIR"
-else
-    # Neither set - warn and exit
-    echo "Error: Matterport3D data directory not specified." >&2
-    echo "" >&2
-    echo "Please set VLMAPS_MP3D_DATA_DIR environment variable or provide it as an argument:" >&2
-    echo "  export VLMAPS_MP3D_DATA_DIR=/path/to/data" >&2
-    echo "  ./scripts/start.bash" >&2
-    echo "Or:" >&2
-    echo "  ./scripts/start.bash /path/to/data" >&2
     exit 1
 fi
 


### PR DESCRIPTION
This pull request updates the VLMaps project to simplify dataset management by standardizing all Matterport3D and VLMaps data paths under a single `data/` directory within the project root. It removes the need for external environment variables and custom Docker volume mounts, streamlining both setup and documentation. Scripts and docs have been refactored to reflect this new approach, making onboarding and usage easier.

**Data Path Standardization**

* All references to external data directories (e.g., `/data/mp3d_data`) have been replaced with project-relative paths such as `data/mp3d` and `data/vlmaps_dataset` in `config/data_paths/default.yaml` and all documentation. [[1]](diffhunk://#diff-a6601cc169bf5a7a4bdff2ddce6b761000cae7d8266a76a548a2b834ed93fc55L1-R2) [[2]](diffhunk://#diff-5b69f71cb8e0da9f6f725463783cdf3ec22ec854ae7710cb7b0c9c2c19f95315L21-R22) [[3]](diffhunk://#diff-5b69f71cb8e0da9f6f725463783cdf3ec22ec854ae7710cb7b0c9c2c19f95315L82-R85) [[4]](diffhunk://#diff-5b69f71cb8e0da9f6f725463783cdf3ec22ec854ae7710cb7b0c9c2c19f95315L185-R192) [[5]](diffhunk://#diff-7b1eb464ef40c031c125cf98cbcf995cc930e4ca3ca7e6dda0b2c2241579e9cfL90-R92) [[6]](diffhunk://#diff-7b1eb464ef40c031c125cf98cbcf995cc930e4ca3ca7e6dda0b2c2241579e9cfL246-R247)

**Documentation Updates**

* The setup and download guides have been rewritten to remove instructions for setting environment variables and mounting external data directories. All data is now handled inside the repo's `data/` folder, and the download script manages everything automatically. [[1]](diffhunk://#diff-0111cfde322b4e7ee3e7b88b6f28dce5347d9040c89e3c899e6b69cdc473a1b4L18-R20) [[2]](diffhunk://#diff-0ba69c6232a5cc3709a8c8b0beeeecd4124129df5950467fa3c90efd53abd3abL25-R31) [[3]](diffhunk://#diff-0ba69c6232a5cc3709a8c8b0beeeecd4124129df5950467fa3c90efd53abd3abL60-R65) [[4]](diffhunk://#diff-0ba69c6232a5cc3709a8c8b0beeeecd4124129df5950467fa3c90efd53abd3abL113-L116) [[5]](diffhunk://#diff-0ba69c6232a5cc3709a8c8b0beeeecd4124129df5950467fa3c90efd53abd3abL135-R107)
* All example commands and expected output structures have been updated to use the new `data/` paths. [[1]](diffhunk://#diff-5b69f71cb8e0da9f6f725463783cdf3ec22ec854ae7710cb7b0c9c2c19f95315L21-R22) [[2]](diffhunk://#diff-5b69f71cb8e0da9f6f725463783cdf3ec22ec854ae7710cb7b0c9c2c19f95315L82-R85) [[3]](diffhunk://#diff-5b69f71cb8e0da9f6f725463783cdf3ec22ec854ae7710cb7b0c9c2c19f95315L185-R192) [[4]](diffhunk://#diff-7b1eb464ef40c031c125cf98cbcf995cc930e4ca3ca7e6dda0b2c2241579e9cfL90-R92) [[5]](diffhunk://#diff-7b1eb464ef40c031c125cf98cbcf995cc930e4ca3ca7e6dda0b2c2241579e9cfL246-R247)

**Script Refactoring**

* The `scripts/download-mp3d.bash` script now downloads and extracts the Matterport3D dataset directly into `data/mp3d` without requiring user prompts for overwriting or config updates. It also removes legacy support for environment variables and external mounts.
* The `scripts/start.bash` script no longer checks for or requires the `VLMAPS_MP3D_DATA_DIR` environment variable or command-line argument, further simplifying container startup. [[1]](diffhunk://#diff-6f153833ca490fc38c5ba26d66ba3d1b9c3cf981fde1f267fefae53594ba3157L4-R4) [[2]](diffhunk://#diff-6f153833ca490fc38c5ba26d66ba3d1b9c3cf981fde1f267fefae53594ba3157L18-L38)

**Docker Compose Simplification**

* The `docker-compose.yml` file no longer mounts external data volumes, relying solely on the project-local `data` folder, which is included in the main project volume.

**Codebase Maintenance**

* Paths and script references in documentation have been updated to reflect the new directory structure (e.g., `cd application/dataset` instead of `cd dataset`). [[1]](diffhunk://#diff-5b69f71cb8e0da9f6f725463783cdf3ec22ec854ae7710cb7b0c9c2c19f95315L67-R67) [[2]](diffhunk://#diff-5b69f71cb8e0da9f6f725463783cdf3ec22ec854ae7710cb7b0c9c2c19f95315L153-R153)

These changes make the project easier to set up and maintain, with all data managed locally and consistently.