### PR TITLE
Fix map space reservation in VLMapBuilder

### DIFF
--- a/vlmaps/map/vlmap_builder.py
+++ b/vlmaps/map/vlmap_builder.py
@@ -152,7 +152,7 @@ class VLMapBuilder:
                 # when the max_id exceeds the reserved size,
                 # double the grid_feat, grid_pos, weight, grid_rgb lengths
                 if max_id >= grid_feat.shape[0]:
-                    self._reserve_map_space(grid_feat, grid_pos, weight, grid_rgb)
+                    grid_feat, grid_pos, weight, grid_rgb = self._reserve_map_space(grid_feat, grid_pos, weight, grid_rgb)
 
                 # apply the distance weighting according to
                 # ConceptFusion https://arxiv.org/pdf/2302.07241.pdf Sec. 4.1, Feature fusion


### PR DESCRIPTION
This pull request updates the logic for expanding map storage arrays in the `create_mobile_base_map` method to correctly handle the return values from the `_reserve_map_space` function. Instead of calling `_reserve_map_space` without updating the arrays, the code now properly assigns the returned expanded arrays to their respective variables.

* Map storage expansion: Updated the call to `_reserve_map_space` to assign the returned expanded arrays (`grid_feat`, `grid_pos`, `weight`, `grid_rgb`) to their corresponding variables, ensuring that the arrays are correctly resized when needed.- Updated the _reserve_map_space method call to directly assign the returned values to grid_feat, grid_pos, weight, and grid_rgb, ensuring proper handling of the reserved map space.
* This change was necessary because _reserve_map_space returns the expanded arrays, but before my edit the return value was ignored, so grid_feat.shape[0] never actually grew and the loop would have hit an out-of-bounds error as soon as max_id exceeded the initial capacity. By assigning the returned grid_feat, grid_pos, weight, grid_rgb, we can actually resize the buffers and keep them aligned.