### PR TITLE
Fix/config issues

### DIFF
--- a/application/dataset/collect_custom_dataset.py
+++ b/application/dataset/collect_custom_dataset.py
@@ -9,7 +9,7 @@ from vlmaps.utils.habitat_utils import *
 
 @hydra.main(
     version_base=None,
-    config_path="../config",
+    config_path="../../config",
     config_name="collect_dataset.yaml",
 )
 def main(config: DictConfig) -> None:

--- a/application/dataset/generate_dataset.py
+++ b/application/dataset/generate_dataset.py
@@ -58,7 +58,7 @@ def generate_scene_data(save_dir: Union[Path, str], config: DictConfig, scene_pa
 
 @hydra.main(
     version_base=None,
-    config_path="../config",
+    config_path="../../config",
     config_name="generate_dataset.yaml",
 )
 def main(config: DictConfig) -> None:

--- a/config/map_indexing_cfg.yaml
+++ b/config/map_indexing_cfg.yaml
@@ -5,7 +5,7 @@ defaults:
   - _self_
 nav:
   valid_range: 1
-  vis: False
+  vis: True
   tasks_per_scene: 20
 scene_id: 0
 

--- a/vlmaps/robot/habitat_lang_robot.py
+++ b/vlmaps/robot/habitat_lang_robot.py
@@ -42,7 +42,7 @@ class HabitatLanguageRobot(LangRobot):
         super().__init__(config)
 
         self.test_scene_dir = self.config["data_paths"]["habitat_scene_dir"]
-        data_dir = Path(self.config["data_paths"]["vlmaps_data_dir"]) / "vlmaps_dataset"
+        data_dir = Path(self.config["data_paths"]["vlmaps_data_dir"]) # / "vlmaps_dataset"
         self.vlmaps_data_save_dirs = [
             data_dir / x for x in sorted(os.listdir(data_dir)) if x != ".DS_Store"
         ]  # ignore artifact generated in MacOS


### PR DESCRIPTION
This pull request contains several configuration and path-related updates to improve dataset handling and visualization in the project. The main changes involve adjusting configuration file paths for Hydra, enabling visualization in the navigation config, and modifying the dataset directory structure in the robot initialization code.

**Configuration and Path Updates:**

* Changed the `config_path` in the Hydra decorators of `collect_custom_dataset.py` and `generate_dataset.py` to point one directory higher, ensuring the correct loading of configuration files. [[1]](diffhunk://#diff-d6fe53e6193d39c9ac295b88212451699ce33021fd9a417af8c61a1e51dfdb2cL12-R12) [[2]](diffhunk://#diff-7b0ee8e192e512b47e1aa40ccfdcf5364437ce701dcf2ab57dd298e659e01236L61-R61)
* Updated the dataset directory assignment in the `HabitatLangRobot` initialization to use the root of `vlmaps_data_dir` instead of appending `"vlmaps_dataset"`, allowing for more flexible data directory structures.

**Visualization Setting:**

* Set `nav.vis` to `True` in `map_indexing_cfg.yaml`, enabling navigation visualization by default.