### PR TITLE
Dev/nav wait key

### DIFF
--- a/config/map_creation_cfg.yaml
+++ b/config/map_creation_cfg.yaml
@@ -5,6 +5,7 @@ defaults:
   - _self_
 nav:
   valid_range: 1
-  vis: False
+  vis: True
+  waitkey: False
   tasks_per_scene: 20
-scene_id: 0
+scene_id: 3

--- a/config/map_indexing_cfg.yaml
+++ b/config/map_indexing_cfg.yaml
@@ -6,8 +6,9 @@ defaults:
 nav:
   valid_range: 1
   vis: True
+  waitkey: False
   tasks_per_scene: 20
-scene_id: 0
+scene_id: 3
 
 # indexing params
 decay_rate: 0.01

--- a/config/object_goal_navigation_cfg.yaml
+++ b/config/object_goal_navigation_cfg.yaml
@@ -5,7 +5,8 @@ defaults:
   - _self_
 nav:
   valid_range: 1
-  vis: False
+  vis: True
   tasks_per_scene: 20
+  waitkey: False
 # scene_id: [1, 2, 3, 4, 5, 6, 7, 8, 9]
-scene_id: 0
+scene_id: 3

--- a/config/spatial_goal_navigation_cfg.yaml
+++ b/config/spatial_goal_navigation_cfg.yaml
@@ -7,5 +7,6 @@ nav:
   valid_range: 1
   vis: True
   tasks_per_scene: 20
+  waitkey: False
 # scene_id: [1, 2, 3, 4, 5, 6, 7, 8, 9]
-scene_id: 0
+scene_id: 3

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -7,7 +7,7 @@ nav:
   valid_range: 1
   vis: True
   tasks_per_scene: 20
-scene_id: 0
+scene_id: 3
 
 # indexing params
 decay_rate: 0.01

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -7,6 +7,7 @@ nav:
   valid_range: 1
   vis: True
   tasks_per_scene: 20
+  waitkey: False
 scene_id: 3
 
 # indexing params

--- a/vlmaps/map/interactive_map.py
+++ b/vlmaps/map/interactive_map.py
@@ -641,7 +641,7 @@ class InteractiveMap:
     config_name="test_config.yaml",
 )
 def main(config: DictConfig) -> None:
-    data_dir = Path(config.data_paths.vlmaps_data_dir) / "vlmaps_dataset"
+    data_dir = Path(config.data_paths.vlmaps_data_dir)
     data_dirs = sorted([x for x in data_dir.iterdir() if x.is_dir()])
     interactive_map = InteractiveMap(data_dirs[config.scene_id], config.map_config)
     # obstacle_cropped = interactive_map.vlmaps_dataloader.get_obstacles_cropped()

--- a/vlmaps/robot/habitat_lang_robot.py
+++ b/vlmaps/robot/habitat_lang_robot.py
@@ -497,7 +497,7 @@ class HabitatLanguageRobot(LangRobot):
 
             real_actions_list.append(action)
             if vis:
-                self.display_obs(waitkey=True)
+                self.display_obs(waitkey=self.config.nav.waitkey)
                 self.display_curr_pos_on_map(map)
             if poses_list is None:
                 continue

--- a/vlmaps/task/habitat_object_nav_task.py
+++ b/vlmaps/task/habitat_object_nav_task.py
@@ -97,7 +97,7 @@ class HabitatObjectNavigationTask(HabitatTask):
             sim.step(action)
             if vis:
                 obs = sim.get_sensor_observations(0)
-                display_sample({}, obs["color_sensor"], waitkey=True)
+                display_sample({}, obs["color_sensor"], waitkey=self.config.nav.waitkey)
         if self.is_task_finished():
             self.n_tot_tasks += 1
             self.n_tot_subgoals += self.n_subgoals_in_task

--- a/vlmaps/task/habitat_spatial_goal_nav_task.py
+++ b/vlmaps/task/habitat_spatial_goal_nav_task.py
@@ -56,7 +56,7 @@ class HabitatSpatialGoalNavigationTask(HabitatTask):
             sim.step(action)
             if vis:
                 obs = sim.get_sensor_observations(0)
-                display_sample({}, obs["color_sensor"], waitkey=True)
+                display_sample({}, obs["color_sensor"], waitkey=self.config.nav.waitkey)
         if self.curr_subgoal_id >= len(self.goals):
             return
         if agent_map_position is None:

--- a/vlmaps/utils/visualize_utils.py
+++ b/vlmaps/utils/visualize_utils.py
@@ -96,6 +96,7 @@ def visualize_heatmap_2d(rgb: np.ndarray, heatmap: np.ndarray, transparency: flo
     Args:
         rgb (np.ndarray): (gs, gs, 3) element range [0, 255] np.uint8
         heatmap (np.ndarray): (gs, gs) element range [0, 1] np.float32
+        waitkey (bool, optional): If True, waits for a key press to proceed. If False, proceeds automatically. Defaults to False.
     """
     sim_new = (heatmap * 255).astype(np.uint8)
     heat = cv2.applyColorMap(sim_new, cv2.COLORMAP_JET)

--- a/vlmaps/utils/visualize_utils.py
+++ b/vlmaps/utils/visualize_utils.py
@@ -78,7 +78,7 @@ def get_heatmap_from_mask_2d(mask: np.ndarray, cell_size: float = 0.05, decay_ra
     return heatmap
 
 
-def visualize_rgb_map_2d(rgb: np.ndarray):
+def visualize_rgb_map_2d(rgb: np.ndarray, waitkey: bool = False):
     """visualize rgb image
 
     Args:
@@ -87,10 +87,10 @@ def visualize_rgb_map_2d(rgb: np.ndarray):
     rgb = rgb.astype(np.uint8)
     bgr = rgb[:, :, ::-1]
     cv2.imshow("rgb map", bgr)
-    cv2.waitKey(0)
+    cv2.waitKey(0 if waitkey else 1)
 
 
-def visualize_heatmap_2d(rgb: np.ndarray, heatmap: np.ndarray, transparency: float = 0.5):
+def visualize_heatmap_2d(rgb: np.ndarray, heatmap: np.ndarray, transparency: float = 0.5, waitkey: bool = False):
     """visualize heatmap
 
     Args:
@@ -101,14 +101,14 @@ def visualize_heatmap_2d(rgb: np.ndarray, heatmap: np.ndarray, transparency: flo
     heat = cv2.applyColorMap(sim_new, cv2.COLORMAP_JET)
     heat = heat[:, :, ::-1].astype(np.float32)  # convert to RGB
     heat_rgb = heat * transparency + rgb * (1 - transparency)
-    visualize_rgb_map_2d(heat_rgb)
+    visualize_rgb_map_2d(heat_rgb, waitkey=waitkey)
 
 
-def visualize_masked_map_2d(rgb: np.ndarray, mask: np.ndarray):
+def visualize_masked_map_2d(rgb: np.ndarray, mask: np.ndarray, waitkey: bool = False):
     """visualize masked map
 
     Args:
         rgb (np.ndarray): (gs, gs, 3) element range [0, 255] np.uint8
         mask (np.ndarray): (gs, gs) element range [0, 1] np.uint8
     """
-    visualize_heatmap_2d(rgb, mask.astype(np.float32))
+    visualize_heatmap_2d(rgb, mask.astype(np.float32), waitkey=waitkey)


### PR DESCRIPTION
This pull request mainly introduces a configurable `waitkey` parameter for visualization routines and updates configuration files to use a different default scene and visualization settings. The changes improve the flexibility and consistency of visualization behavior across the codebase and make it easier to control interactive pauses during visualizations.

**Configuration changes:**

* Set `nav.vis` to `True` and added `nav.waitkey: False` in multiple config files (`map_creation_cfg.yaml`, `map_indexing_cfg.yaml`, `object_goal_navigation_cfg.yaml`, `spatial_goal_navigation_cfg.yaml`). Also changed `scene_id` from `0` to `3` for these configs, and for `test_config.yaml` as well. [[1]](diffhunk://#diff-4898c6b249406cb660f5c6cf2bece1d4f31759d1cd8222a23d4452a84c8368f6L8-R11) [[2]](diffhunk://#diff-5fb04ea1bd81226b9637268025635e58fc27c1d1430ea5e4243324eabb6eea66R9-R11) [[3]](diffhunk://#diff-97ef19226c47453903fc7578b0177a778a49652fec5b1accbab310ceac64bdfdL8-R12) [[4]](diffhunk://#diff-4b3d673168fc693bcaf7a36f4b93320115299c964579ebd7beab01cfd36c19d3R10-R12) [[5]](diffhunk://#diff-95bb94008d1b2a61ad9271096c82dfdb98bb349fd522198ea373a686a6c2c0d4L10-R10)

**Visualization improvements:**

* Added a `waitkey` parameter to visualization utility functions (`visualize_rgb_map_2d`, `visualize_heatmap_2d`, `visualize_masked_map_2d`) in `visualize_utils.py`, allowing control over whether the display waits for a key press or proceeds automatically. [[1]](diffhunk://#diff-ee8a7125b8a91127af355aae29af68db3632cb90e2007934f8efd45e765c0453L81-R81) [[2]](diffhunk://#diff-ee8a7125b8a91127af355aae29af68db3632cb90e2007934f8efd45e765c0453L90-R93) [[3]](diffhunk://#diff-ee8a7125b8a91127af355aae29af68db3632cb90e2007934f8efd45e765c0453L104-R114)
* Updated calls to visualization functions in robot and task classes to use the new `waitkey` configuration value, ensuring consistent behavior based on the config. [[1]](diffhunk://#diff-136a34a7c957bc667f7d356fb11f565faf683bb10cad59f518102e99b6cc8618L500-R500) [[2]](diffhunk://#diff-5acf3e7e2303a31f48cafb44750275561e51c11ad5d40c39f283494fb215ef64L100-R100) [[3]](diffhunk://#diff-d0ac85875da84be7d8cd01ac6ff0a90c8117f6f4eb9923989dc349c47094e63dL59-R59)

**Other improvements:**

* Adjusted the data directory path construction in `interactive_map.py` to remove the hardcoded `"vlmaps_dataset"` subdirectory, making it more flexible.